### PR TITLE
include link to original bip on github.

### DIFF
--- a/pages/[bip].js
+++ b/pages/[bip].js
@@ -48,7 +48,7 @@ export async function getStaticProps({ params }) {
     let data = markdown.toJSON(file)
     if (!data.body) throw new Error(`Failed to parse markdown page for ${bipFile}.md`)
     const title = `BIP${(params.bip)} - ${file.substring(file.indexOf('Title: ') + 7, file.indexOf('Author: '))}`
-    const originalURL = `https://github.com/bitcoin/bips/blob/master/bip-${params.bip.padStart(4, '0')}.mediawiki`
+    const originalURL = `https://github.com/bitcoin/bips/blob/master/${bipFile}.mediawiki`
 
     const content = data.body
         // Replace bip-0001.mediawiki url format by 1

--- a/pages/[bip].js
+++ b/pages/[bip].js
@@ -48,8 +48,13 @@ export async function getStaticProps({ params }) {
     let data = markdown.toJSON(file)
     if (!data.body) throw new Error(`Failed to parse markdown page for ${bipFile}.md`)
     const title = `BIP${(params.bip)} - ${file.substring(file.indexOf('Title: ') + 7, file.indexOf('Author: '))}`
-    //Replace bip-0001.mediawiki url format by 1
-    const content = data.body.replace(/bip-(\d{1,4}).mediawiki/g, (_, bipNumber) => parseInt(bipNumber))
+    const originalURL = `https://github.com/bitcoin/bips/blob/master/bip-${params.bip.padStart(4, '0')}.mediawiki`
+
+    const content = data.body
+        // Replace bip-0001.mediawiki url format by 1
+        .replace(/bip-(\d{1,4}).mediawiki/g, (_, bipNumber) => parseInt(bipNumber))
+        // link to original BIP file in preamble
+        .replace(/  BIP: \d{1,4}/, (_) => _ + ` <small><a href="${originalURL}" target="_blank">source</a></small>`)
     return {
         props: {
             title,


### PR DESCRIPTION
This adds a small link to the original BIP URL on the official BIPs repo to each BIP page.

Probably looks crappy, but I think this link must exist _somewhere_.
