### PR TITLE
fix: get a bip even when left padded with zeroes

### DIFF
--- a/app/services/bip_service.ts
+++ b/app/services/bip_service.ts
@@ -2,7 +2,8 @@ import Bip from '#models/bip'
 import cache from '@adonisjs/cache/services/main'
 
 export default class BipService {
-  public async getBip(bipNumber: string) {
+  public async getBip(bipStr: string) {
+    const bipNumber = Number.parseInt(bipStr)
     const bip = await cache.namespace('bips').get<Bip>(bipNumber)
     return bip
   }


### PR DESCRIPTION
See https://bips.xyz/141#block-size and click the link leading to bip144 (which is actually referring to `./0141`)